### PR TITLE
added categories, rrule, exrule, rdate and exdate to calendar events

### DIFF
--- a/django_ical/feedgenerator.py
+++ b/django_ical/feedgenerator.py
@@ -62,6 +62,11 @@ ITEM_EVENT_FIELD_MAP = (
     ('geolocation',         'geo'),
     ('link',                'url'),
     ('organizer',           'organizer'),
+    ('categories',          'categories'),
+    ('rrule',               'rrule'),
+    ('exrule',              'exrule'),
+    ('rdate',               'rdate'),
+    ('exdate',              'exdate'),
 )
 
 

--- a/django_ical/views.py
+++ b/django_ical/views.py
@@ -42,6 +42,10 @@ ICAL_EXTRA_FIELDS = [
     'location',         # location
     'geolocation',      # latitude;longitude
     'organizer',        # email, cn, and role
+    'rrule',            # rrule
+    'exrule',           # exrule
+    'rdate',            # rdate
+    'exdate',           # exdate
 ]
 
 # For Django <1.7


### PR DESCRIPTION
Hi @pinkerton, I added support for the rrule field (issue #3) and by the way also for exrule, rdate, exdate. Also categories!

The item_rrule and item_exrule functions must return a list of dictionaries containing the rule, e.g. when item holds a list of rrule.rrule
```python
def item_rrule(self, item):
    rrules = item.rrules
    return [ dict([ y.split('=') for y in z.split(';') ]) for z in rrules ]
```

Unfortunately my time is so short that I could not provide any tests so far.

