### PR TITLE
Remove support for Python 2.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 sudo: true
 
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 envlist =
-    {py26,py27}-django{13,14,15,16}
+    {py27}-django{13,14,15,16}
     {py27,py34}-django{17}
     {py27,py34,py35}-django{18,19,110}
     {py27,py34,py35,py36}-django{111}
@@ -10,7 +10,6 @@ envlist =
 
 [testenv]
 deps =
-    py26: ordereddict
     six
     django13: Django>=1.3,<1.4
     django14: Django>=1.4,<1.5


### PR DESCRIPTION
Our dependency `icalendar` dropped support for Python 2.6 in 4.0.

As discussed in https://github.com/pinkerton/django-ical/issues/13